### PR TITLE
Wordpress Nginx Fix CFN Init #1 and Add EFS Support #2

### DIFF
--- a/labs/wordpress/example_parameters/wordpress-nginx.json
+++ b/labs/wordpress/example_parameters/wordpress-nginx.json
@@ -46,5 +46,29 @@
   {
     "ParameterKey": "InstanceType",
     "ParameterValue": "t2.micro"
+  },
+  {
+    "ParameterKey": "EfsMountPoint",
+    "ParameterValue": "/path/to/mount1"
+  },
+  {
+    "ParameterKey": "EfsFileSystemId",
+    "ParameterValue": "fs-00000000"
+  },
+  {
+    "ParameterKey": "DbHost",
+    "ParameterValue": "db.domain.com"
+  },
+  {
+    "ParameterKey": "DbName",
+    "ParameterValue": "mediawiki"
+  },
+  {
+    "ParameterKey": "DbUser",
+    "ParameterValue": "mediawiki"
+  },
+  {
+    "ParameterKey": "DbPassword",
+    "ParameterValue": "secret"
   }
 ]

--- a/labs/wordpress/wordpress-nginx.yml
+++ b/labs/wordpress/wordpress-nginx.yml
@@ -34,6 +34,14 @@ Parameters:
     Description: DNS Record Name (www.example.com)
     Default: www.example.com
 
+  # EFS Mount
+  EfsMountPoint:
+    Type: String
+    Default: /path/to/mount1
+  EfsFileSystemId:
+    Type: String
+    Default: fs-00000000
+
   # Instance
   KeyPairName:
     Type: AWS::EC2::KeyPair::KeyName
@@ -63,6 +71,107 @@ Parameters:
     MinLength: '8'
     AllowedPattern: "[a-zA-Z0-9!?]*"
     ConstraintDescription: Must only contain upper and lowercase letters, numbers and contain a minimum of 8 characters
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+     # Ownership
+      - Label:
+          default: Ownership
+        Parameters:
+          - Owner
+          - DeleteAfter
+
+      # Network
+      - Label:
+          default: Network
+        Parameters:
+          - VPC
+          - SubnetId
+          - SecurityGroup
+          - InternalAccessSecurityGroup
+          - RemoteSecurityGroup
+          - RdsSecurityGroup
+          - EfsSecurityGroup
+
+      # Instance Settings
+      - Label:
+          default: Instance
+        Parameters:
+          - KeyPairName
+          - InstanceType
+
+      # DNS
+      - Label:
+          default: DNS
+        Parameters:
+          - RecordName
+          - HostedZoneId
+
+      # EFS
+      - Label:
+          default: EFS
+        Parameters:
+          - EfsMountPoint
+          - EfsFileSystemId
+
+      # Database
+      - Label:
+          default: Database Config
+        Parameters:
+          - DbHost
+          - DbName
+          - DbUser
+          - DbPassword
+
+    ParameterLabels:
+      # Ownership
+      Owner:
+        default: Team or Individual Owner
+      DeleteAfter:
+        default: Delete After Date
+
+      # Network
+      VPC:
+        default: VPC ID
+      SubnetId:
+        default: Subnet ID
+      InternalAccessSecurityGroup:
+        default: Internal Access Security Group
+      RemoteSecurityGroup:
+        default: Remote Security Group
+      RdsSecurityGroup:
+        default: RDS Security Group
+      EfsSecurityGroup:
+        default: EFS Security Group
+
+      # Instance Settings
+      KeyPairName:
+        default: EC2 Key Pair Name
+      InstanceType:
+        default: Instance Type
+
+      # DNS
+      RecordName:
+        default: Record Name
+      HostedZoneId:
+        default: Hosted Zone ID
+
+      # EFS
+      EfsMountPoint:
+        default: EFS Mount Point
+      EfsFileSystemId:
+        default: EFS File System Id
+
+      # Database
+      DbHost:
+        default: Database Host
+      DbName:
+        default: Database Name
+      DbUser:
+        default: Database User
+      DbPassword:
+        default: Database Password
 
 Mappings:
   RegionMap:
@@ -245,6 +354,7 @@ Resources:
           yum update -y
           yum install -y aws-cfn-bootstrap cloud-init aws-cli
           /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region} --configsets ec2_setup
+          /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region}
 
     Metadata:
       AWS::CloudFormation::Init:
@@ -252,6 +362,7 @@ Resources:
           ec2_setup:
             - config_cfn
             - install_packages
+            - setup_uploads_efs
             - config_wordpress
             - config_php_fpm
             - start_services
@@ -272,8 +383,8 @@ Resources:
               content: !Sub |
                 [cfn-auto-reloader-hook]
                 triggers=post.update
-                path=Resources.LaunchConfiguration.Metadata.AWS::CloudFormation::Init
-                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource LaunchConfiguration --region ${AWS::Region} --configsets ec2_setup
+                path=Resources.EC2Instance.Metadata.AWS::CloudFormation::Init
+                action=/opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource EC2Instance --region ${AWS::Region} --configsets ec2_setup
                 runas=root
           services:
             sysvinit:
@@ -286,19 +397,29 @@ Resources:
         install_packages:
           commands:
             01_install_nginx:
-              command: "yum install -y nginx mysql56 php70-fpm php70-mysqlnd php70-gd php70-mbstring php70-mcrypt"
+              command: "yum install -y htop vim mlocate git nginx mysql56 php70-fpm php70-mysqlnd php70-gd php70-mbstring php70-mcrypt"
             02_download_wordpress:
               cwd: /tmp/
               command: "wget https://wordpress.org/latest.tar.gz"
-            03_extract_wordpress:
+            03_create_www:
+              command: "mkdir -p /var/www/html"
+            04_extract_wordpress:
               cwd: /tmp/
-              command: "tar -xvzf latest.tar.gz -C /usr/share/nginx/html/"
-            04_setup_wordpress:
-              cwd: /usr/share/nginx/html/
-              command: "chown -R nginx:nginx /usr/share/nginx/html/wordpress"
+              command: "tar -xvzf latest.tar.gz -C /var/www/html/"
             05_chmod_wordpress:
-              cwd: /usr/share/nginx/html/
-              command: "chown -R nginx:nginx /usr/share/nginx/html/wordpress"
+              cwd: /var/www/html/
+              command: "chown -R nginx:nginx /var/www/html/wordpress"
+        setup_uploads_efs:
+          commands:
+            01_make_mount_dir:
+              cwd: /var/www/html
+              command: !Sub "mkdir -p ${EfsMountPoint}"
+            02_update_fstab:
+              cwd: /var/www/html
+              command: !Sub |
+                echo "${EfsFileSystemId}.efs.${AWS::Region}.amazonaws.com:/ ${EfsMountPoint} nfs4 nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0" >> /etc/fstab
+            03_mount_efs:
+              command: "mount -a -t nfs4"
         config_wordpress:
           files:
             "/etc/nginx/conf.d/wordpress.conf":
@@ -306,7 +427,7 @@ Resources:
                 server {
                         listen 80;
                         server_name ${RecordName};
-                        root   /usr/share/nginx/html/wordpress;
+                        root   /var/www/html/wordpress;
                         index index.php index.html index.htm;
                         #access_log /var/log/nginx/wordpress_access.log;
                         #error_log /var/log/nginx/wordpress_error.log;
@@ -320,7 +441,7 @@ Resources:
 
                         location @handler {
                             fastcgi_pass 127.0.0.1:9000;
-                            fastcgi_param SCRIPT_FILENAME /usr/share/nginx/html/wordpress/index.php;
+                            fastcgi_param SCRIPT_FILENAME /var/www/html/wordpress/index.php;
                             include /etc/nginx/fastcgi_params;
                             fastcgi_param SCRIPT_NAME /index.php;
                         }
@@ -329,30 +450,24 @@ Resources:
                             try_files $uri @handler;
                             fastcgi_pass    127.0.0.1:9000;
                             fastcgi_index   index.php;
-                            fastcgi_param SCRIPT_FILENAME /usr/share/nginx/html/wordpress$fastcgi_script_name;
+                            fastcgi_param SCRIPT_FILENAME /var/www/html/wordpress$fastcgi_script_name;
                             include fastcgi_params;
                         }
 
-                        location = /favicon.ico {
-                            log_not_found off;
-                            access_log off;
-                         }
+                        # Plugin Handles This
+                        #location = /favicon.ico { access_log off; log_not_found off; }
 
-                        location = /robots.txt {
-                            allow all;
-                            log_not_found off;
-                            access_log off;
-                        }
+                        # Plugin Handles This
+                        #location = /robots.txt { access_log off; log_not_found off; allow all; }
 
-                        location ~ /\. {
-                            deny all;
-                        }
+                        #    Prevent access to any files starting with a dot, like .htaccess or text editor temp files
+                        location ~ /\. { access_log off; log_not_found off; deny all; }
 
                         location ~* /(?:uploads|files)/.*\.php$ {
                             deny all;
                         }
                 }
-            "/usr/share/nginx/html/wordpress/wp-config.php":
+            "/var/www/html/wordpress/wp-config.php":
               mode: "000444"
               content: !Sub |
                 <?php
@@ -376,7 +491,7 @@ Resources:
                 //** MySQL settings **//
 
                 //define('WP_CACHE', true); //Added by WP-Cache Manager
-                //define( 'WPCACHEHOME', '/usr/share/nginx/html/fitnessjerk/wordpress/wp-content/plugins/wp-super-cache/' ); //Added by WP-Cache Manager
+                //define( 'WPCACHEHOME', '/var/www/html/fitnessjerk/wordpress/wp-content/plugins/wp-super-cache/' ); //Added by WP-Cache Manager
                 define('DB_NAME', '${DbName}');
                 define('DB_USER', '${DbUser}');
                 define('DB_PASSWORD', '${DbPassword}');
@@ -421,6 +536,8 @@ Resources:
               command: "sed -i 's/apache/nginx/g' /etc/php-fpm-7.0.d/www.conf"
             02_set_ownership_logs_dir:
               command: "chown -R nginx:nginx /var/log/php-fpm"
+            03_set_ownership_session_dir:
+              command: "chown -R root:nginx /var/lib/php/7.0/"
         start_services:
           commands:
             01_start_php_fpm:
@@ -468,6 +585,10 @@ Resources:
           commands:
             01_warm_ebs:
               command: "echo 'ACTION: Performing EBS Warming' && dd if=/dev/xvda of=/dev/xvda conv=notrunc bs=1M status=progress"
+      CreationPolicy:
+        ResourceSignal:
+          Count: 1
+          Timeout: PT20M
 
 Outputs:
   # Ownership
@@ -519,91 +640,3 @@ Outputs:
   HostedZoneId:
     Description: Hosted Zone ID.
     Value: !Ref HostedZoneId
-
-Metadata:
-  AWS::CloudFormation::Interface:
-    ParameterGroups:
-     # Ownership
-      - Label:
-          default: Ownership
-        Parameters:
-          - Owner
-          - DeleteAfter
-
-      # Network
-      - Label:
-          default: Network
-        Parameters:
-          - VPC
-          - SubnetId
-          - SecurityGroup
-          - InternalAccessSecurityGroup
-          - RemoteSecurityGroup
-          - RdsSecurityGroup
-          - EfsSecurityGroup
-
-      # Instance Settings
-      - Label:
-          default: Instance
-        Parameters:
-          - KeyPairName
-          - InstanceType
-
-      # DNS
-      - Label:
-          default: DNS
-        Parameters:
-          - RecordName
-          - HostedZoneId
-
-      # Database
-      - Label:
-          default: Database Config
-        Parameters:
-          - DbHost
-          - DbName
-          - DbUser
-          - DbPassword
-
-    ParameterLabels:
-      # Ownership
-      Owner:
-        default: Team or Individual Owner
-      DeleteAfter:
-        default: Delete After Date
-
-      # Network
-      VPC:
-        default: VPC ID
-      SubnetId:
-        default: Subnet ID
-      InternalAccessSecurityGroup:
-        default: Internal Access Security Group
-      RemoteSecurityGroup:
-        default: Remote Security Group
-      RdsSecurityGroup:
-        default: RDS Security Group
-      EfsSecurityGroup:
-        default: EFS Security Group
-
-      # Instance Settings
-      KeyPairName:
-        default: EC2 Key Pair Name
-      InstanceType:
-        default: Instance Type
-
-      # DNS
-      RecordName:
-        default: Record Name
-      HostedZoneId:
-        default: Hosted Zone ID
-
-      # Database
-      DbHost:
-        default: Database Host
-      DbName:
-        default: Database Name
-      DbUser:
-        default: Database User
-      DbPassword:
-        default: Database Password


### PR DESCRIPTION
# Changes
[x] Fix Issue
[x] Feature Add
[ ] Refactor
[ ] Documentation
[ ] Other

# Change Details
* Fixed resource call to be Ec2Instance instead of LaunchConfiguration in cfn-init update script
* Added EFS parameters and cfn-init logic for mounting EFS volume using fstab
* Updated parameters file example
* Moved the install location to **/var/www/html/wordpress**. Just easier to type and most are used to it. Guess I could have done /opt/wordpress or something. on well, it's better than /usr/share/nginx/html/wordpress... 

# Test Details
* Stood instance up using CFN Launcher

# Links
* [Related Issue 1](https://github.com/bonusbits/cloudformation_templates/issues/1)
* [Related Issue 2](https://github.com/bonusbits/cloudformation_templates/issues/2)